### PR TITLE
Use urlparse.urljoin() instead of str.join()

### DIFF
--- a/django_behave/splinter.steps_library.py
+++ b/django_behave/splinter.steps_library.py
@@ -1,3 +1,5 @@
+from urlparse import urljoin
+
 from behave import *
 
 """
@@ -21,7 +23,7 @@ def any_startpoint(context):
 
 @given(u'the user accesses the url "{url}"')
 def the_user_accesses_the_url(context, url):
-    full_url = ''.join([context.config.server_url, url])
+    full_url = urljoin(context.config.server_url, url)
     context.browser.visit(full_url)
 
 


### PR DESCRIPTION
`urlparse.urljoin()` takes care of a couple of things which may be missed if `str.join()` is used.

Please have a look at [documentation of `urlparse.urljoin()`](http://docs.python.org/2/library/urlparse.html#urlparse.urljoin) and it's [implementation](http://hg.python.org/cpython/file/026ee0057e2d/Lib/urlparse.py#l250).
