### PR TITLE
Fixed bug where normal Django long form test options were treated like b...

### DIFF
--- a/django_behave/runner.py
+++ b/django_behave/runner.py
@@ -43,7 +43,7 @@ def get_options():
         ),
     )
 
-    option_info = {}
+    option_info = {"--behave_browser": True}
 
     for fixed, keywords in options:
         # Look for the long version of this option

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 setup(
     name='django-behave',
     packages=['django_behave'],
-    version='0.0.14',
+    version='0.0.15',
     description='Django Test Runner for the Behave BDD module',
     author='Rachel Willmer',
     author_email='rachel@willmer.org',


### PR DESCRIPTION
Fixed bug where normal Django long form test options were treated like behave options (which caused a KeyError).  Fixed to ensure only behave options are parsed and stored.

Also, updated the package version number.
