### PR TITLE
don't hide other test results when there are behave failures

### DIFF
--- a/django_behave/runner.py
+++ b/django_behave/runner.py
@@ -160,12 +160,7 @@ class DjangoBehaveTestCase(LiveServerTestCase):
         # from behave/__main__.py
         #stream = self.behave_config.output
         runner = BehaveRunner(self.behave_config)
-        try:
-            failed = runner.run()
-        except ParserError as e:
-            sys.exit(str(e))
-        except ConfigError as e:
-            sys.exit(str(e))
+        failed = runner.run()
 
         try:
             undefined_steps = runner.undefined_steps
@@ -195,7 +190,7 @@ class DjangoBehaveTestCase(LiveServerTestCase):
             sys.stderr.flush()
 
         if failed:
-            sys.exit(1)
+            raise AssertionError('There were behave failures, see output above')
         # end of from behave/__main__.py
 
 


### PR DESCRIPTION
The calls to `sys.exit` were left over from a copy-pasted code block from the `behave.__main__`

However, the django test runner runs both standard django unit tests as well as the behave features.

Before this commit, if there were behave failures, we didn't get the standard test result output, and thus if there were unit test failures, we weren't informed about them either.
