### PR TITLE
changed skip dotted labels to use last part

### DIFF
--- a/django_behave/runner.py
+++ b/django_behave/runner.py
@@ -212,8 +212,7 @@ class DjangoBehaveTestSuiteRunner(BaseRunner):
         # always get all features for given apps (for convenience)
         for label in test_labels:
             if '.' in label:
-                print("Ignoring label with dot in: %s" % label)
-                continue
+                label = label.split('.')[-1]
             app = get_app(label)
 
             # Check to see if a separate 'features' module exists,


### PR DESCRIPTION
I had a problem with the original implementation, because it did not find my tests.
Directorty structure:
proj_home/
--manage.py
--apps/
----app1/
--------features/
--------features/environment.py 
--------features/userfeeds.feature
--------features/steps/
--------features/steps/app1.py
--------tests/
[ + some additional stuff]

INSTALLED_APPS = [...,
    'apps.app1']

now it does and i dont see any complications.



