### PR TITLE
Separate Settings file for django-behave

### DIFF
--- a/django_behave/app_settings.py
+++ b/django_behave/app_settings.py
@@ -24,6 +24,12 @@ class AppSettings(object):
     def ENABLE_STATIC_TEST_SERVER(self):
         return self._setting("ENABLE_STATIC_TEST_SERVER", False)
 
+    # Allows fixtures to be specified in the projects settings file
+    # more modular design
+    @property
+    def FIXTURES(self):
+        return self._setting("FIXTURES", '')
+
 # Ugly? Guido recommends this himself ...
 # http://mail.python.org/pipermail/python-ideas/2012-May/014969.html
 import sys

--- a/django_behave/app_settings.py
+++ b/django_behave/app_settings.py
@@ -1,0 +1,32 @@
+class AppSettings(object):
+
+    def __init__(self, prefix):
+        self.prefix = prefix
+
+    def _setting(self, name, dflt):
+        from django.conf import settings
+        getter = getattr(settings,
+                         'DJANGO_BEHAVE_SETTING_GETTER',
+                         lambda name, dflt: getattr(settings, name, dflt))
+        return getter(self.prefix + name, dflt)
+
+    # Before Django 1.7 LiveServerTestCase used to rely on the
+    # staticfiles contrib app to get the static assets of the
+    # application(s) under test transparently served at their
+    # expected locations during the execution of these tests.
+
+    # In Django 1.7 this dependency of core functionality on a
+    # contrib application has been removed, because of which
+    # LiveServerTestCase ability in this respect has been
+    # retrofitted to simply publish the contents of the file
+    # system under STATIC_ROOT at the STATIC_URL URL.
+    @property
+    def ENABLE_STATIC_TEST_SERVER(self):
+        return self._setting("ENABLE_STATIC_TEST_SERVER", False)
+
+# Ugly? Guido recommends this himself ...
+# http://mail.python.org/pipermail/python-ideas/2012-May/014969.html
+import sys
+app_settings = AppSettings('DJANGO_BEHAVE_')
+app_settings.__name__ = __name__
+sys.modules[__name__] = app_settings

--- a/django_behave/runner.py
+++ b/django_behave/runner.py
@@ -17,12 +17,8 @@ from behave.runner import Runner as BehaveRunner
 from behave.parser import ParserError
 from behave.formatter.ansi_escapes import escapes
 from . import app_settings
-#test
-#from django.test.utils import override_settings
-import sys
 
-# import logging
-# log = logging.getLogger("runner.py")
+import sys
 
 
 def get_app_dir(app_module):
@@ -117,6 +113,7 @@ def parse_argv(argv, option_info):
 
     return (new_argv, our_opts)
 
+
 def _base_test_server_class():
     """
     By default inherit from LiveServerTestCase. This is all
@@ -129,9 +126,10 @@ def _base_test_server_class():
         return StaticLiveServerTestCase
     return LiveServerTestCase
 
-#@override_settings(DEBUG=True)
+
 class DjangoBehaveTestCase(_base_test_server_class()):
-    fixtures = ['fixtures/socialaccounts.json', 'fixtures/sites.json']
+    fixtures = app_settings.FIXTURES
+
     def __init__(self, **kwargs):
         self.features_dir = kwargs.pop('features_dir')
         self.option_info = kwargs.pop('option_info')


### PR DESCRIPTION
Two main changes were made. Both allow end users to configure settings for django-behave through their projects settings file(s). I have provided a separate django-behave app_settings.py module, which specify an initial state for both settings and by default provide the same functionality as the current project. The two settings I added are set using: DJANGO_BEHAVE_FIXTURES and DJANGO_BEHAVE_ENABLE_STATIC_TEST_SERVER.

The first setting allows users to easily specify fixtures in an existing project settings module. This gives users the convenience of being able to provide initial values for their test database without having to make changes to django-behave code. This setting defaults to an empty string and can be overridden by specifying a tuple of strings, all of which point django-behave to a different fixture.

The second setting allows for django1.7+ integration by allowing static files to be served in one of two possible ways. The LiveServerTestCase documentation: https://docs.djangoproject.com/en/1.7/topics/testing/tools/ explains this issue for django1.7. Static files are handled differently by LiveServerTestCase and StaticLiveServerTestCase for django1.7+. This settings allows a user to choose either base class by overriding the setting to either True (uses StaticLiveServerTestCase) or False (uses LiveServerTestCase). If no override is provided, the setting defaults to False, which maintains the current standard.