### PR TITLE
Remove python 2.6 support, since django no longer supports it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
@@ -14,19 +13,11 @@ env:
 # Django 1.4 doesn't support Python 3
 matrix:
   exclude:
-    - python: "2.6"
-      env: DJANGO=django==1.7
-    - python: "2.6"
-      env: DJANGO=django==1.8
     - python: "3.3"
       env: DJANGO=django==1.4.13
     - python: "3.4"
       env: DJANGO=django==1.4.13
-# command to install dependencies
-# unittest2 should be only installed for python 2.6
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 importlib argparse; fi
   - pip install $DJANGO
   - "pip install -r requirements.txt"
-# command to run tests
 script: python tests.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/django-behave/django-behave.svg?branch=master)](https://travis-ci.org/django-behave/django-behave)  
 Tested on:
-- Python 2.6, 2.7 
+- Python 2.7 
 - Python 3.3, 3.4 
 - Django v1.4-1.8
 

--- a/django_behave/runner.py
+++ b/django_behave/runner.py
@@ -31,7 +31,8 @@ try:
 except ImportError:
     from django.db.models import get_app
 
-from django.utils import six, unittest
+import unittest
+from django.utils import six
 from django.utils.six.moves import xrange
 
 from behave.configuration import Configuration, ConfigError, options


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/topics/testing/overview/

> Since Django no longer supports Python versions older than 2.7,
  django.utils.unittest is deprecated. Simply use unittest.