### PR TITLE
Return appconfig.module if .models_module is None

### DIFF
--- a/django_behave/runner.py
+++ b/django_behave/runner.py
@@ -26,7 +26,8 @@ try:
     from django.apps import apps
 
     def get_app(label):
-        return apps.get_app_config(label).models_module
+        appconfig = apps.get_app_config(label)
+        return appconfig.models_module or appconfig.module
 
 except ImportError:
     from django.db.models import get_app


### PR DESCRIPTION
I have my behave tests in a separate django app `bdd_tests`,
which doesn't contain any models. This change fixes an
error I was getting where the result of `get_app()` was `None`.

Fixes #50