### PR TITLE
Remove trailing slash for app names

### DIFF
--- a/django_behave/runner.py
+++ b/django_behave/runner.py
@@ -26,6 +26,10 @@ try:
     from django.apps import apps
 
     def get_app(label):
+        if label.endswith('/'):
+            print("Removing trailing slash of label: %s" % label)
+            label = label[:-1]
+
         appconfig = apps.get_app_config(label)
         return appconfig.models_module or appconfig.module
 


### PR DESCRIPTION
*TL;DR: commit makes runner remove trailing spaces when resolving app names*

Not sure if this should be merged into `master`, but here's a shot at it.

I run tests by executing `./manage.py test <appname>` with tab-autocompleting `<appname>`. Autocompletion works since I run the said command within the Django project's root directory which, by convention, houses app directories.

The issue is that (at least for Linux Mint MATE's `mate-terminal`; haven't confirmed with other flavors), autocompletion of directories leaves a trailing slash (e.g., `./manage.py test someapp/`) which results in an exception with message `LookupError: No installed app with label 'someapp/'.`.

I do realize that there are other ways to achieve the same result from the client end (`reverse-i-search` comes to mind), but it may be better to have the module itself handle instances of the said case.

Thanks!